### PR TITLE
Debounced inline provider

### DIFF
--- a/src/main/kotlin/co/huggingface/llmintellij/LlmLsCompletionProvider.kt
+++ b/src/main/kotlin/co/huggingface/llmintellij/LlmLsCompletionProvider.kt
@@ -21,7 +21,7 @@ import kotlin.time.DurationUnit
 import kotlin.time.toDuration
 
 class LlmLsCompletionProvider : DebouncedInlineCompletionProvider() {
-    override val delay: Duration = 500.toDuration(DurationUnit.MILLISECONDS)
+    override var delay: Duration = 500.toDuration(DurationUnit.MILLISECONDS)
     private val logger = Logger.getInstance("inlineCompletion")
     override fun force(request: InlineCompletionRequest): Boolean {
         return false
@@ -34,6 +34,7 @@ class LlmLsCompletionProvider : DebouncedInlineCompletionProvider() {
                 logger.error("could not find project")
             } else {
                 val settings = LlmSettingsState.instance
+                delay = settings.debounceDelay
                 val secrets = SecretsService.instance
                 val lspServer = LspServerManager.getInstance(project).getServersForProvider(LlmLsServerSupportProvider::class.java).firstOrNull()
                 if (lspServer != null) {

--- a/src/main/kotlin/co/huggingface/llmintellij/LlmSettingsComponent.kt
+++ b/src/main/kotlin/co/huggingface/llmintellij/LlmSettingsComponent.kt
@@ -16,6 +16,9 @@ import javax.swing.JComponent
 import javax.swing.JPanel
 import javax.swing.event.DocumentEvent
 import javax.swing.event.DocumentListener
+import kotlin.time.Duration
+import kotlin.time.DurationUnit
+import kotlin.time.toDuration
 
 class LlmSettingsComponent {
     val rootPanel: JPanel = JPanel()
@@ -41,6 +44,8 @@ class LlmSettingsComponent {
     private val fimSuffixLabel: JBLabel
     private val fimSuffix: JBTextField
     private val tlsSkipVerifyInsecure: JBCheckBox
+    private val debounceDelayLabel: JBLabel
+    private val debounceDelay: JBTextField
     private val lspBinaryPath: TextFieldWithBrowseButton
     private val lspVersionLabel: JBLabel
     private val lspVersion: JBTextField
@@ -218,6 +223,11 @@ class LlmSettingsComponent {
         llmLsSubsectionPanel.add(lspLogLevelLabel)
         llmLsSubsectionPanel.add(lspLogLevel)
 
+        val pluginSettingsPanel = createSectionPanel("Plugin settings", rootPanel)
+        debounceDelayLabel = JBLabel("Debounce delay in milliseconds")
+        debounceDelay = JBTextField("500")
+        pluginSettingsPanel.add(debounceDelayLabel)
+        pluginSettingsPanel.add(debounceDelay)
     }
 
     val preferredFocusedComponent: JComponent
@@ -351,6 +361,14 @@ class LlmSettingsComponent {
 
     fun setLspLogLevel(value: String) {
         lspLogLevel.text = value
+    }
+
+    fun getDebounceDelay(): Duration {
+        return debounceDelay.text.toInt().toDuration(DurationUnit.MILLISECONDS)
+    }
+
+    fun setDebounceDelay(value: Duration) {
+        debounceDelay.text = value.inWholeMilliseconds.toString()
     }
 
     fun getLspBinaryPath(): String? {

--- a/src/main/kotlin/co/huggingface/llmintellij/LlmSettingsConfigurable.kt
+++ b/src/main/kotlin/co/huggingface/llmintellij/LlmSettingsConfigurable.kt
@@ -3,6 +3,8 @@ package co.huggingface.llmintellij
 import com.intellij.openapi.options.Configurable
 import org.jetbrains.annotations.Nls
 import javax.swing.JComponent
+import kotlin.time.DurationUnit
+import kotlin.time.toDuration
 
 
 class LlmSettingsConfigurable : Configurable {
@@ -38,6 +40,7 @@ class LlmSettingsConfigurable : Configurable {
         modified = modified or (settingsComponent?.getFimMiddle() != settings.fim.middle)
         modified = modified or (settingsComponent?.getFimSuffix() != settings.fim.suffix)
         modified = modified or (settingsComponent?.isTlsSkipVerifyInsecureEnabled() != settings.tlsSkipVerifyInsecure)
+        modified = modified or (settingsComponent?.getDebounceDelay() != settings.debounceDelay)
         modified = modified or (settingsComponent?.getLspBinaryPath() != settings.lsp.binaryPath)
         modified = modified or (settingsComponent?.getLspVersion() != settings.lsp.version)
         modified = modified or (settingsComponent?.getLspLogLevel() != settings.lsp.logLevel)
@@ -60,6 +63,7 @@ class LlmSettingsConfigurable : Configurable {
         settings.fim.middle = settingsComponent?.getFimMiddle() ?: ""
         settings.fim.suffix = settingsComponent?.getFimSuffix() ?: ""
         settings.tlsSkipVerifyInsecure = settingsComponent?.isTlsSkipVerifyInsecureEnabled() ?: false
+        settings.debounceDelay = settingsComponent?.getDebounceDelay() ?: 500.toDuration(DurationUnit.MILLISECONDS)
         settings.lsp.binaryPath = settingsComponent?.getLspBinaryPath()
         settings.lsp.version = settingsComponent?.getLspVersion() ?: ""
         settings.lsp.logLevel = settingsComponent?.getLspLogLevel() ?: ""
@@ -81,6 +85,7 @@ class LlmSettingsConfigurable : Configurable {
         settingsComponent?.setFimMiddle(settings.fim.middle)
         settingsComponent?.setFimSuffix(settings.fim.suffix)
         settingsComponent?.setTlsSkipVerifyInsecureStatus(settings.tlsSkipVerifyInsecure)
+        settingsComponent?.setDebounceDelay(settings.debounceDelay)
         settingsComponent?.setLspBinaryPath(settings.lsp.binaryPath ?: "")
         settingsComponent?.setLspVersion(settings.lsp.version)
         settingsComponent?.setLspLogLevel(settings.lsp.logLevel)

--- a/src/main/kotlin/co/huggingface/llmintellij/LlmSettingsState.kt
+++ b/src/main/kotlin/co/huggingface/llmintellij/LlmSettingsState.kt
@@ -5,6 +5,8 @@ import com.intellij.openapi.components.PersistentStateComponent
 import com.intellij.openapi.components.State
 import com.intellij.openapi.components.Storage
 import com.intellij.util.xmlb.XmlSerializerUtil
+import kotlin.time.DurationUnit
+import kotlin.time.toDuration
 
 
 class LspSettings {
@@ -45,6 +47,7 @@ class LlmSettingsState: PersistentStateComponent<LlmSettingsState?> {
     var queryParams = QueryParams()
     var fim = FimParams()
     var tlsSkipVerifyInsecure = false
+    var debounceDelay = 500.toDuration(DurationUnit.MILLISECONDS)
     var lsp = LspSettings()
     var tokenizer: TokenizerConfig? = TokenizerConfig.HuggingFace("bigcode/starcoder")
     var contextWindow = 8192u


### PR DESCRIPTION
I changed the Inline Completion Provider to a debounced version to avoid unnecessary completion requests to the inference endpoint.
The debounce delay is configureable via the settings page, but gets only active after the next completion request (it was the easiest way ;)).